### PR TITLE
Allow the first name/last name to appear in the registration form everywhere

### DIFF
--- a/bp-xprofile-wp-user-sync.php
+++ b/bp-xprofile-wp-user-sync.php
@@ -341,7 +341,7 @@ class BpXProfileWordPressUserSync {
 						if ( isset( $group->fields ) AND is_array( $group->fields ) ) {
 							
 							// get user ID
-							$user_id = intval( $_GET['user_id'] );
+							$user_id = isset( $_GET['user_id'] ) ? intval( $_GET['user_id'] ) : 0 ;
 							
 							// only edit other users profiles
 							if ( $user_id AND get_current_user_id() != $user_id ) {


### PR DESCRIPTION
Allow the First name/Last name to appear everywhere in the registration form. The current code only allows it to appear on registration page( site/register using bp_is_register_page). I have changed that to allow it work everywhere for the registration form.
