### PR TITLE
Filter params prior to query

### DIFF
--- a/bp-xprofile-wp-user-sync.php
+++ b/bp-xprofile-wp-user-sync.php
@@ -81,7 +81,7 @@ class BpXProfileWordPressUserSync {
 	function translation() {
 
 		// only use, if we have it...
-		if( function_exists('load_plugin_textdomain') ) {
+		if ( function_exists( 'load_plugin_textdomain' ) ) {
 
 			// not used, as there are no translations as yet
 			load_plugin_textdomain(
@@ -398,7 +398,7 @@ class BpXProfileWordPressUserSync {
 
 		// test for new BP xProfile admin screen
 
-		// get buddypress instance
+		// get BuddyPress instance
 		$bp = buddypress();
 
 		// test for new BP_Members_Admin object
@@ -567,7 +567,7 @@ class BpXProfileWordPressUserSync {
 			);
 
 			/**
-			 * When XProfiles are updated, BuddyPress sets user nickname and display name
+			 * When xProfiles are updated, BuddyPress sets user nickname and display name
 			 * so we should too...
 			 */
 
@@ -662,7 +662,7 @@ class BpXProfileWordPressUserSync {
 	public function intercept_wp_fb_profile_sync( $facebook_user, $wp_user_id ) {
 
 		/**
-		 * When XProfiles are updated, BuddyPress sets user nickname and display name
+		 * When xProfiles are updated, BuddyPress sets user nickname and display name
 		 * so WP FB AutoConnect Premium should do too. To do so, alter line 1315 or so:
 		 *
 		 * //A filter so 3rd party plugins can process any extra fields they might need

--- a/bp-xprofile-wp-user-sync.php
+++ b/bp-xprofile-wp-user-sync.php
@@ -294,7 +294,7 @@ class BpXProfileWordPressUserSync {
 		// do we have a version of BuddyPress capable of pre-filtering?
 		if ( function_exists( 'bp_parse_args' ) ) {
 
-			// use bp_parse_args post-parse filter
+			// use bp_parse_args post-parse filter (available since BP 2.0)
 			add_filter( 'bp_after_has_profile_parse_args', array( $this, 'intercept_profile_query_args' ), 30, 1 );
 
 		} else {
@@ -305,7 +305,7 @@ class BpXProfileWordPressUserSync {
 
 		}
 
-		// exclude the default name field type on profile fields admin screen
+		// exclude the default name field type on profile fields admin screen (available since BP 2.1)
 		add_filter( 'bp_xprofile_get_groups', array( $this, 'intercept_profile_fields_query' ), 30, 2 );
 
 		// populate our fields on user registration and update by admins
@@ -343,11 +343,8 @@ class BpXProfileWordPressUserSync {
 		// if on profile edit screen
 		if ( bp_is_user_profile_edit() ) {
 
-			// get field id from name
-			$fullname_field_id = xprofile_get_field_id_from_name( bp_xprofile_fullname_field_name() );
-
-			// exclude name field
-			$args['exclude_fields'] = $fullname_field_id;
+			// exclude name field (bp_xprofile_fullname_field_id is available since BP 2.0)
+			$args['exclude_fields'] = bp_xprofile_fullname_field_id();
 
 		}
 
@@ -367,11 +364,8 @@ class BpXProfileWordPressUserSync {
 			// query only group 1
 			$args['profile_group_id'] = 1;
 
-			// get field id from name
-			$fullname_field_id = xprofile_get_field_id_from_name( bp_xprofile_fullname_field_name() );
-
-			// exclude name field
-			$args['exclude_fields'] = $fullname_field_id;
+			// exclude name field (bp_xprofile_fullname_field_id is available since BP 2.0)
+			$args['exclude_fields'] = bp_xprofile_fullname_field_id();
 
 		}
 
@@ -586,11 +580,8 @@ class BpXProfileWordPressUserSync {
 		// bail if not in admin
 		if ( ! is_admin() ) return $groups;
 
-		// get field id from name
-		$fullname_field_id = xprofile_get_field_id_from_name( bp_xprofile_fullname_field_name() );
-
 		// exclude name field
-		$args['exclude_fields'] = $fullname_field_id;
+		$args['exclude_fields'] = bp_xprofile_fullname_field_id();
 
 		// re-query the groups
 		$groups = BP_XProfile_Group::get( $args );

--- a/bp-xprofile-wp-user-sync.php
+++ b/bp-xprofile-wp-user-sync.php
@@ -397,8 +397,34 @@ class BpXProfileWordPressUserSync {
 		// if on profile view screen
 		if ( bp_is_user_profile() AND !bp_is_user_profile_edit() ) {
 
-			// exclude our xprofile fields
-			$args['exclude_fields'] = implode( ',', $this->options );
+			// comma-delimit our fields
+			$exclude_fields = implode( ',', $this->options );
+
+			/**
+			 * Exclude our xprofile fields, but allow filtering. All relevant params
+			 * are passed to the filter so that other plugins can make an informed
+			 * choice of what to return.
+			 *
+			 * To retain the first name and last name fields, an appropriate way to
+			 * do this would look something like:
+			 *
+			 * add_filter( 'bp_xprofile_wp_user_sync_exclude_fields', 'my_function' );
+			 * function my_function( $exclude_fields ) {
+			 *     return bp_xprofile_fullname_field_id();
+			 * }
+			 *
+			 * @param string $exclude_fields Comma-delimited pseudo-array of custom fields
+			 * @param array $options Array of custom field IDs
+			 * @param boolean $has_groups True if groups exist, false otherwise
+			 * @param object $profile_template The BuddyPress profile template object
+			 */
+			$args['exclude_fields'] = apply_filters(
+				'bp_xprofile_wp_user_sync_exclude_fields',
+				$exclude_fields,
+				$this->options,
+				$has_groups,
+				$profile_template
+			);
 
 		}
 


### PR DESCRIPTION
The function `bp_parse_args()` allows the profile query to be amended before it is called. Do this when it is available.
